### PR TITLE
Fixed persisting interact button after distillation.

### DIFF
--- a/Content/MightyHibiscus/Blueprint/LevelCode/BP_Snail.uasset
+++ b/Content/MightyHibiscus/Blueprint/LevelCode/BP_Snail.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d81cb61e9ee3b670ee258fc470254b63284d3060e350ca89bcaf5aad554cb2d5
-size 418529
+oid sha256:c376c3841a0f850679204f30d043955213bf34ee7fce4991890cd37b4809c15d
+size 465414

--- a/Content/MightyHibiscus/Blueprint/PotionCraftingEquipment/CBP_Alembic.uasset
+++ b/Content/MightyHibiscus/Blueprint/PotionCraftingEquipment/CBP_Alembic.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b2ed4c04e7c57971ef472142888bf1651b64e6a06ee0ba41f4334be9c19e613
-size 2256164
+oid sha256:79a7ac61f2e5303c473ed35c807c85d4aa636409880703d9d8f7214ceabe4e3b
+size 2294684


### PR DESCRIPTION
The alembic's collection prompt should now be hidden after player exits/collects all ingredients, and reappear when player is inside of snail and has ingredients yet to collect.